### PR TITLE
fix markdown 00317.md

### DIFF
--- a/text/00317.md
+++ b/text/00317.md
@@ -55,14 +55,11 @@ $rover = new dog();
 $rover->setName('rover');
 echo $rover->getName();
 
-{% endhighlight %}
+```
 
 Установка и вызов свойства `name` напрямую может позволить скрипту работать до 100% быстрее, так-же, как и сократить время разработки.
 
-{% highlight php %}
-
-<?php
-
+```php
 $rover = new dog();
 $rover->name = 'rover';
 echo $rover->name;


### PR DESCRIPTION
Фикс разметки. А вообще стоит убрать эту статью, так как преждевременная оптимизация - корень всех зол. Т.е. статья вредная для новичков.